### PR TITLE
Fixed duplicate output content

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ npm install --save-dev @fluffy-spoon/csharp-to-typescript-generator.webpack
 
 # Use
 ```javascript
-var gulp = require('gulp');
 var poco = require('@fluffy-spoon/csharp-to-typescript-generator.webpack');
 
 var webpackConfig = {

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -48,14 +48,17 @@ Plugin.prototype.apply = function(compiler) {
                 .join(
                     that.outputDirectory, 
                     fileName.substring(0, fileName.length - 2) + that.extension);
-            compilation.assets[outputFilePath] = {
-                source: function() {
-                    return typescriptCode;
-                },
-                size: function() {
-                    return typescriptCode.length;
-                }
-            };
+
+            (function (outputPath, ts) {
+                compilation.assets[outputPath] = {
+                    source: function() {
+                        return ts;
+                    },
+                    size: function() {
+                        return ts.length;
+                    }
+                };
+            })(outputFilePath, typescriptCode);
         }
 
         callback();


### PR DESCRIPTION
This resolves the issue where each output file had the content of the last file processed. It also removes the reference to gulp in the readme.